### PR TITLE
DEV: Use plugin api version 1.13.0

### DIFF
--- a/javascripts/discourse/api-initializers/discourse-svgbob.js
+++ b/javascripts/discourse/api-initializers/discourse-svgbob.js
@@ -135,7 +135,7 @@ function updateMarkdownHeight(svgbob, index) {
   }
 }
 
-export default apiInitializer("1.15.0", (api) => {
+export default apiInitializer("1.13.0", (api) => {
   // this is a hack as applySurround expects a top level
   // composer key, not possible from a theme
   window.I18n.translations[window.I18n.locale].js.composer.svgbob_sample = `


### PR DESCRIPTION
Plugin API versions > 1.13 is not released in any beta versions.