### PR TITLE
DEV: Update post-stream detection following core change

### DIFF
--- a/javascripts/discourse/api-initializers/discourse-svgbob.js
+++ b/javascripts/discourse/api-initializers/discourse-svgbob.js
@@ -157,7 +157,8 @@ export default apiInitializer("1.13.0", (api) => {
 
   api.decorateCookedElement(
     async (elem, helper) => {
-      const id = helper ? `post_${helper.getModel().id}` : "composer";
+      const post = helper?.getModel();
+      const id = post ? `post_${post.id}` : "composer";
       applySvgbob(elem, id);
     },
     { id: "discourse-svgbob" }


### PR DESCRIPTION
The helper is now available in all decoration locations, so we should gate this logic on the presence of the post model instead.